### PR TITLE
Feat: 핵심결과 생성

### DIFF
--- a/src/main/java/com/slamdunk/WORK/controller/KeyResultController.java
+++ b/src/main/java/com/slamdunk/WORK/controller/KeyResultController.java
@@ -1,7 +1,13 @@
 package com.slamdunk.WORK.controller;
 
+import com.slamdunk.WORK.dto.request.KeyResultRequest;
+import com.slamdunk.WORK.security.UserDetailsImpl;
 import com.slamdunk.WORK.service.KeyResultService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -9,5 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class KeyResultController {
     private final KeyResultService keyResultService;
 
-
+    //핵심결과 생성
+    @PostMapping("api/keyresult")
+    public ResponseEntity<?> registerKeyResult(
+            @RequestBody KeyResultRequest keyResultRequest,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return keyResultService.registerKeyResult(keyResultRequest, userDetails);
+    }
 }

--- a/src/main/java/com/slamdunk/WORK/dto/request/KeyResultRequest.java
+++ b/src/main/java/com/slamdunk/WORK/dto/request/KeyResultRequest.java
@@ -6,5 +6,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class KeyResultRequest {
+    private Long objectiveId;
     private String keyResult;
 }

--- a/src/main/java/com/slamdunk/WORK/entity/KeyResult.java
+++ b/src/main/java/com/slamdunk/WORK/entity/KeyResult.java
@@ -15,7 +15,10 @@ public class KeyResult extends TimeStamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "keyResult_id")
     private Long id;
-    @Column(unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "objective_id")
+    private Objective objective;
+    @Column(nullable = false)
     private String keyResult;
     @Column
     private int progress;

--- a/src/main/java/com/slamdunk/WORK/service/KeyResultService.java
+++ b/src/main/java/com/slamdunk/WORK/service/KeyResultService.java
@@ -1,13 +1,22 @@
 package com.slamdunk.WORK.service;
 
+import com.slamdunk.WORK.dto.request.KeyResultRequest;
 import com.slamdunk.WORK.repository.KeyResultRepository;
+import com.slamdunk.WORK.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class KeyResultService {
     private final KeyResultRepository keyResultRepository;
 
+    @Transactional
+    public ResponseEntity<?> registerKeyResult(KeyResultRequest keyResultRequest, UserDetailsImpl userDetails) {
 
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
 }


### PR DESCRIPTION
- 해당 부분에서 잠시 논의 필요
- 현재 와이어프레임과 기능서에서는 핵심결과의 상위 객체인 목표 객체를 알 수가 없음
- 그래서 목표와 핵심결과 생성 팝업창의 분리가 필요