### PR TITLE
Fix: 핵심결과 생성 API

### DIFF
--- a/src/main/java/com/slamdunk/WORK/entity/UserKeyResult.java
+++ b/src/main/java/com/slamdunk/WORK/entity/UserKeyResult.java
@@ -23,11 +23,14 @@ public class UserKeyResult {
     @JoinColumn(name = "keyResult_id")
     private KeyResult keyResult;
     @Column
+    private String team;
+    @Column
     private boolean deleteState;
 
-    public UserKeyResult(User user, Objective objective, KeyResult keyResult) {
+    public UserKeyResult(User user, Objective objective, KeyResult keyResult, String team) {
         this.user = user;
         this.objective = objective;
         this.keyResult = keyResult;
+        this.team = team;
     }
 }

--- a/src/main/java/com/slamdunk/WORK/service/UserKeyResultService.java
+++ b/src/main/java/com/slamdunk/WORK/service/UserKeyResultService.java
@@ -29,7 +29,7 @@ public class UserKeyResultService {
         Optional<KeyResult> keyResultCheck = keyResultRepository.findById(keyResult.getId());
 
         if (objectiveCheck.isPresent() && keyResultCheck.isPresent()) {
-            UserKeyResult userKeyResult = new UserKeyResult(userDetails.getUser(), objectiveCheck.get(), keyResult);
+            UserKeyResult userKeyResult = new UserKeyResult(userDetails.getUser(), objectiveCheck.get(), keyResult, userDetails.getUser().getTeam());
             userKeyResultRepository.save(userKeyResult);
         }
     }


### PR DESCRIPTION
- 핵심결과 생성시 생기는 중간테이블에 팀 이름 삽입
- 현재 목표, 핵심결과, 목표-핵심결과 조회는 생성한 사람만 가능
- 해당 컬럼을 통해 자신의 팀이 만든 목표, 핵심결과를 조회하도록 변경