### PR TITLE
Fix: 핵심결과 전체 조회 API

### DIFF
--- a/src/main/java/com/slamdunk/WORK/repository/UserKeyResultRepository.java
+++ b/src/main/java/com/slamdunk/WORK/repository/UserKeyResultRepository.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface UserKeyResultRepository extends JpaRepository<UserKeyResult, Long> {
-    List<UserKeyResult> findAllByUserId(Long userId);
-    List<UserKeyResult> findAllByObjectiveId(Long ObjectiveId);
+    List<UserKeyResult> findAllByTeam(String team);
     Optional<UserKeyResult> findByKeyResultIdAndUserId(Long KeyResultId, Long userId);
 }

--- a/src/main/java/com/slamdunk/WORK/service/UserKeyResultService.java
+++ b/src/main/java/com/slamdunk/WORK/service/UserKeyResultService.java
@@ -36,7 +36,7 @@ public class UserKeyResultService {
 
     //회원-핵심결과 중간테이블 전체 조회
     public List<Long> allKeyResult(UserDetailsImpl userDetails) {
-        List<UserKeyResult> userKeyResultList = userKeyResultRepository.findAllByUserId(userDetails.getUser().getId());
+        List<UserKeyResult> userKeyResultList = userKeyResultRepository.findAllByTeam(userDetails.getUser().getTeam());
 
         List<Long> keyResultId = new ArrayList<>();
         for (int i =0; i<userKeyResultList.size(); i++) {


### PR DESCRIPTION
- 중간테이블에 팀으로 검색을 하여 로그인한 유저가 속한 팀이 생성한 전체 핵심결과 조회가능