### PR TITLE
Feat: 목표 삭제 API

### DIFF
--- a/src/main/java/com/slamdunk/WORK/Editor/ObjectiveEditor.java
+++ b/src/main/java/com/slamdunk/WORK/Editor/ObjectiveEditor.java
@@ -12,13 +12,15 @@ public class ObjectiveEditor {
     private LocalDate enddate;
     private String color;
     private int progress;
+    private boolean deleteState;
 
     @Builder
-    public ObjectiveEditor(String objective, LocalDate startdate, LocalDate enddate, String color, int progress) {
+    public ObjectiveEditor(String objective, LocalDate startdate, LocalDate enddate, String color, int progress, boolean deleteState) {
         this.objective = objective;
         this.startdate = startdate;
         this.enddate = enddate;
         this.color = color;
         this.progress = progress;
+        this.deleteState = deleteState;
     }
 }

--- a/src/main/java/com/slamdunk/WORK/controller/ObjectiveController.java
+++ b/src/main/java/com/slamdunk/WORK/controller/ObjectiveController.java
@@ -54,4 +54,12 @@ public class ObjectiveController {
             @RequestBody ObjectiveEditRequest objectiveEditRequest) {
         return objectiveService.objectiveEdit(objectiveId, userDetails, objectiveEditRequest);
     }
+
+    //목표 삭제
+    @DeleteMapping("api/objective/{objective_id}")
+    public ResponseEntity<String> objectiveDelete(
+            @PathVariable("objective_id") Long objectiveId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return objectiveService.objectiveDelete(objectiveId, userDetails);
+    }
 }

--- a/src/main/java/com/slamdunk/WORK/entity/Objective.java
+++ b/src/main/java/com/slamdunk/WORK/entity/Objective.java
@@ -45,6 +45,7 @@ public class Objective extends TimeStamped {
         endDate = objectiveEditor.getEnddate();
         color = objectiveEditor.getColor();
         progress = objectiveEditor.getProgress();
+        deleteState = objectiveEditor.isDeleteState();
     }
 
     public ObjectiveEditor.ObjectiveEditorBuilder ObjectiveToEditor() {
@@ -54,6 +55,7 @@ public class Objective extends TimeStamped {
                 .startdate(startDate)
                 .enddate(endDate)
                 .color(color)
-                .progress(progress);
+                .progress(progress)
+                .deleteState(deleteState);
     }
 }

--- a/src/main/java/com/slamdunk/WORK/service/ObjectiveService.java
+++ b/src/main/java/com/slamdunk/WORK/service/ObjectiveService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -166,6 +167,30 @@ public class ObjectiveService {
                     editObjective.get().ObjectiveEdit(objectiveEditor);
                 }
                 return new ResponseEntity<>("목표가 수정 되었습니다.", HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>("존재하지 않는 목표입니다.", HttpStatus.BAD_REQUEST);
+            }
+        } else {
+            return new ResponseEntity<>("수정 권한이 없습니다.", HttpStatus.FORBIDDEN);
+        }
+    }
+
+    //목표 삭제
+    @Transactional
+    public ResponseEntity<String> objectiveDelete(Long objectiveId, UserDetailsImpl userDetails) {
+        if (userObjectiveService.checkMyObjective(objectiveId, userDetails)) {
+            Optional<Objective> deleteObjective = objectiveRepository.findById(objectiveId);
+            if (deleteObjective.isPresent()) {
+                if (!deleteObjective.get().isDeleteState()) {
+                    ObjectiveEditor.ObjectiveEditorBuilder objectiveEditorBuilder = deleteObjective.get().ObjectiveToEditor();
+                    ObjectiveEditor objectiveEditor = objectiveEditorBuilder
+                            .deleteState(true)
+                            .build();
+                    deleteObjective.get().ObjectiveEdit(objectiveEditor);
+                    return new ResponseEntity<>("목표가 삭제 되었습니다.", HttpStatus.OK);
+                } else {
+                    return new ResponseEntity<>("이미 삭제된 목표입니다.", HttpStatus.BAD_REQUEST);
+                }
             } else {
                 return new ResponseEntity<>("존재하지 않는 목표입니다.", HttpStatus.BAD_REQUEST);
             }


### PR DESCRIPTION
- DB에서 데이터를 삭제하는 하드delete가 아닌 상태값을 바꾸는 소프트delete를 사용
- 에디터에 해당 값을 수정하기 위해 delete상태값 추가
- 단, 현재 목표 삭제시 하위 객체인 핵심결과와 할일의 경우 삭제처리 안됨 ㄴ일단 목표 삭제와 핵심결과 삭제 기능 구현후 해당 문제 해결