### PR TITLE
Feat: 핵심결과 삭제 API

### DIFF
--- a/src/main/java/com/slamdunk/WORK/Editor/KeyResultEditor.java
+++ b/src/main/java/com/slamdunk/WORK/Editor/KeyResultEditor.java
@@ -8,11 +8,13 @@ public class KeyResultEditor {
     private String keyResult;
     private int progress;
     private int emoticon;
+    private boolean deleteState;
 
     @Builder
-    public KeyResultEditor(String keyResult, int progress, int emoticon) {
+    public KeyResultEditor(String keyResult, int progress, int emoticon, boolean deleteState) {
         this.keyResult = keyResult;
         this.progress = progress;
         this.emoticon = emoticon;
+        this.deleteState =deleteState;
     }
 }

--- a/src/main/java/com/slamdunk/WORK/controller/KeyResultController.java
+++ b/src/main/java/com/slamdunk/WORK/controller/KeyResultController.java
@@ -67,4 +67,12 @@ public class KeyResultController {
             @RequestBody KeyResultEditRequest keyResultEditRequest) {
         return keyResultService.keyResultEdit(keyResultId, userDetails, keyResultEditRequest);
     }
+
+    //핵심결과 삭제
+    @DeleteMapping("api/keyresult/{keyresult_id}")
+    public ResponseEntity<?> keyResultDelete(
+            @PathVariable("keyresult_id") Long keyResultId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return keyResultService.keyResultDelete(keyResultId, userDetails);
+    }
 }

--- a/src/main/java/com/slamdunk/WORK/entity/KeyResult.java
+++ b/src/main/java/com/slamdunk/WORK/entity/KeyResult.java
@@ -38,6 +38,7 @@ public class KeyResult extends TimeStamped {
         keyResult = keyResultEditor.getKeyResult();
         progress = keyResultEditor.getProgress();
         emoticon = keyResultEditor.getEmoticon();
+        deleteState = keyResultEditor.isDeleteState();
     }
 
     public KeyResultEditor.KeyResultEditorBuilder KeyResultToEditor() {
@@ -45,6 +46,7 @@ public class KeyResult extends TimeStamped {
                 .builder()
                 .keyResult(keyResult)
                 .progress(progress)
-                .emoticon(emoticon);
+                .emoticon(emoticon)
+                .deleteState(deleteState);
     }
 }

--- a/src/main/java/com/slamdunk/WORK/service/KeyResultService.java
+++ b/src/main/java/com/slamdunk/WORK/service/KeyResultService.java
@@ -181,4 +181,29 @@ public class KeyResultService {
             return new ResponseEntity<>("수정 권한이 없습니다.", HttpStatus.FORBIDDEN);
         }
     }
+
+    //핵심결과 삭제
+    @Transactional
+    public ResponseEntity<?> keyResultDelete(Long keyResultId, UserDetailsImpl userDetails) {
+        if (userKeyResultService.checkMyKeyResult(keyResultId, userDetails)) {
+            Optional<KeyResult> deleteKeyResult = keyResultRepository.findById(keyResultId);
+            if (deleteKeyResult.isPresent()) {
+                if (!deleteKeyResult.get().isDeleteState()) {
+                    KeyResultEditor.KeyResultEditorBuilder keyResultEditorBuilder = deleteKeyResult.get().KeyResultToEditor();
+                    KeyResultEditor keyResultEditor = keyResultEditorBuilder
+                            .deleteState(true)
+                            .build();
+                    deleteKeyResult.get().KeyResultEdit(keyResultEditor);
+                    
+                    return new ResponseEntity<>("핵심결과가 삭제 되었습니다.", HttpStatus.OK);
+                } else {
+                    return new ResponseEntity<>("이미 삭제된 핵심결과입니다.", HttpStatus.BAD_REQUEST);
+                }
+            } else {
+                return new ResponseEntity<>("존재하지 않는 핵심결과입니다.", HttpStatus.BAD_REQUEST);
+            }
+        } else {
+            return new ResponseEntity<>("삭제 권한이 없습니다.", HttpStatus.FORBIDDEN);
+        }
+    }
 }

--- a/src/main/java/com/slamdunk/WORK/service/ObjectiveService.java
+++ b/src/main/java/com/slamdunk/WORK/service/ObjectiveService.java
@@ -187,6 +187,7 @@ public class ObjectiveService {
                             .deleteState(true)
                             .build();
                     deleteObjective.get().ObjectiveEdit(objectiveEditor);
+
                     return new ResponseEntity<>("목표가 삭제 되었습니다.", HttpStatus.OK);
                 } else {
                     return new ResponseEntity<>("이미 삭제된 목표입니다.", HttpStatus.BAD_REQUEST);
@@ -195,7 +196,7 @@ public class ObjectiveService {
                 return new ResponseEntity<>("존재하지 않는 목표입니다.", HttpStatus.BAD_REQUEST);
             }
         } else {
-            return new ResponseEntity<>("수정 권한이 없습니다.", HttpStatus.FORBIDDEN);
+            return new ResponseEntity<>("삭제 권한이 없습니다.", HttpStatus.FORBIDDEN);
         }
     }
 }


### PR DESCRIPTION
- DB에서 데이터를 삭제하는 하드delete가 아닌 상태값을 바꾸는 소프트delete를 사용
- 에디터에 해당 값을 수정하기 위해 delete상태값 추가
- 단, 현재 핵심결과 삭제시 하위 객체인 할일의 경우 삭제처리 안됨 ㄴ일단 핵심결과 삭제 기능 구현후 해당 문제 해결