### PR TITLE
Fix: 핵심결과를 조회하는 모든 API

### DIFF
--- a/src/main/java/com/slamdunk/WORK/repository/KeyResultRepository.java
+++ b/src/main/java/com/slamdunk/WORK/repository/KeyResultRepository.java
@@ -2,9 +2,14 @@ package com.slamdunk.WORK.repository;
 
 import com.slamdunk.WORK.entity.KeyResult;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface KeyResultRepository extends JpaRepository<KeyResult, Long> {
     List<KeyResult> findAllByObjectiveId(Long ObjectiveId);
+    @Query("SELECT k FROM KeyResult k WHERE k.id = :keyResultId AND k.deleteState = false")
+    Optional<KeyResult> findByIdAndDeleteStateFalse(@Param("keyResultId")Long keyResultId);
 }

--- a/src/main/java/com/slamdunk/WORK/service/KeyResultService.java
+++ b/src/main/java/com/slamdunk/WORK/service/KeyResultService.java
@@ -62,7 +62,7 @@ public class KeyResultService {
 
         List<KeyResultResponse> keyResultResponseList = new ArrayList<>();
         for (int i=0; i<keyResultId.size(); i++) {
-        Optional<KeyResult> keyResult = keyResultRepository.findById(keyResultId.get(i));
+        Optional<KeyResult> keyResult = keyResultRepository.findByIdAndDeleteStateFalse(keyResultId.get(i));
             if (keyResult.isPresent()) {
                 KeyResultResponse keyResultResponse = KeyResultResponse.builder()
                         .myKeyResult(userKeyResultService.checkMyKeyResult(keyResult.get().getId(), userDetails))
@@ -81,7 +81,7 @@ public class KeyResultService {
 
     //핵심결과 상세 조회
     public ResponseEntity<?> detailKeyResult(Long keyResultId, UserDetailsImpl userDetails) {
-        Optional<KeyResult> keyResult = keyResultRepository.findById(keyResultId);
+        Optional<KeyResult> keyResult = keyResultRepository.findByIdAndDeleteStateFalse(keyResultId);
         if (keyResult.isPresent()) {
             KeyResultDetailResponse keyResultDetailResponse = KeyResultDetailResponse.builder()
                     .myKeyResult(userKeyResultService.checkMyKeyResult(keyResultId, userDetails))
@@ -98,7 +98,7 @@ public class KeyResultService {
     //핵심결과 진척도 수정
     @Transactional
     public ResponseEntity<String> keyResultProgressEdit(Long keyResultId, UserDetailsImpl userDetails, ProgressRequest progressRequest) {
-        Optional<KeyResult> keyResult = keyResultRepository.findById(keyResultId);
+        Optional<KeyResult> keyResult = keyResultRepository.findByIdAndDeleteStateFalse(keyResultId);
 
         if (keyResult.isPresent()) {
             if (userKeyResultService.checkMyKeyResult(keyResultId, userDetails)) {
@@ -130,7 +130,7 @@ public class KeyResultService {
     //핵심결과 자신감 수정
     @Transactional
     public ResponseEntity<String> keyResultEmoticonEdit(Long keyResultId, UserDetailsImpl userDetails, EmoticonRequest emoticonRequest) {
-        Optional<KeyResult> keyResult = keyResultRepository.findById(keyResultId);
+        Optional<KeyResult> keyResult = keyResultRepository.findByIdAndDeleteStateFalse(keyResultId);
 
         if (keyResult.isPresent()) {
             if (userKeyResultService.checkMyKeyResult(keyResultId, userDetails)) {
@@ -163,7 +163,7 @@ public class KeyResultService {
     @Transactional
     public ResponseEntity<?> keyResultEdit(Long keyResultId, UserDetailsImpl userDetails, KeyResultEditRequest keyResultEditRequest) {
         if (userKeyResultService.checkMyKeyResult(keyResultId, userDetails)) {
-            Optional<KeyResult> editKeyResult = keyResultRepository.findById(keyResultId);
+            Optional<KeyResult> editKeyResult = keyResultRepository.findByIdAndDeleteStateFalse(keyResultId);
             if (editKeyResult.isPresent()) {
                 KeyResultEditor.KeyResultEditorBuilder keyResultEditorBuilder = editKeyResult.get().KeyResultToEditor();
                 if (keyResultEditRequest.getKeyResult() != null) {


### PR DESCRIPTION
- 전체, 상세, 진척도, 자신감, 수정의 API에서 핵심결과 데이터를 불러올때 삭제처리된 데이터를 불러오지 않기 위해 신규 jpa 메소드 추가