### PR TITLE
fix: 목표 생성 api, 목표 관련 조회 api

### DIFF
--- a/src/main/java/com/slamdunk/WORK/repository/UserObjectiveRepository.java
+++ b/src/main/java/com/slamdunk/WORK/repository/UserObjectiveRepository.java
@@ -2,11 +2,14 @@ package com.slamdunk.WORK.repository;
 
 import com.slamdunk.WORK.entity.UserObjective;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface UserObjectiveRepository extends JpaRepository<UserObjective, Long> {
-    List<UserObjective> findAllByTeam(String team);
+    @Query("SELECT uo FROM UserObjective uo inner join Objective o on uo.objective.id = o.id WHERE uo.team = :team AND o.deleteState = false order by o.endDate")
+    List<UserObjective> findAllByTeam(@Param("team") String team);
     Optional<UserObjective> findByObjectiveIdAndUserId(Long ObjectiveId, Long userId);
 }

--- a/src/main/java/com/slamdunk/WORK/service/ObjectiveService.java
+++ b/src/main/java/com/slamdunk/WORK/service/ObjectiveService.java
@@ -37,22 +37,27 @@ public class ObjectiveService {
     @Transactional
     public ResponseEntity<?> registerObjective(ObjectiveRequest objectiveRequest, UserDetailsImpl userDetails) {
         if (userDetails.getUser().getTeamPosition().equals("팀장")) {
-            Objective newObjective = new Objective(objectiveRequest);
-            objectiveRepository.save(newObjective);
+            List<Long> objectiveIdList = userObjectiveService.allObjective(userDetails);
+            if (objectiveIdList.size() < 4) {
+                Objective newObjective = new Objective(objectiveRequest);
+                objectiveRepository.save(newObjective);
 
-            userObjectiveService.registerUserObjective(newObjective, userDetails);
+                userObjectiveService.registerUserObjective(newObjective, userDetails);
 
-            ObjectiveResponse objectiveResponse = ObjectiveResponse.builder()
-                    .myObjective(userObjectiveService.checkMyObjective(newObjective.getId(), userDetails))
-                    .objectiveId(newObjective.getId())
-                    .objective(newObjective.getObjective())
-                    .startdate(newObjective.getStartDate())
-                    .enddate(newObjective.getEndDate())
-                    .color(newObjective.getColor())
-                    .progress(newObjective.getProgress())
-                    .build();
+                ObjectiveResponse objectiveResponse = ObjectiveResponse.builder()
+                        .myObjective(userObjectiveService.checkMyObjective(newObjective.getId(), userDetails))
+                        .objectiveId(newObjective.getId())
+                        .objective(newObjective.getObjective())
+                        .startdate(newObjective.getStartDate())
+                        .enddate(newObjective.getEndDate())
+                        .color(newObjective.getColor())
+                        .progress(newObjective.getProgress())
+                        .build();
 
-            return new ResponseEntity<>(objectiveResponse, HttpStatus.CREATED);
+                return new ResponseEntity<>(objectiveResponse, HttpStatus.CREATED);
+            } else {
+                return new ResponseEntity<>("생성된 목표가 최대치 입니다.", HttpStatus.BAD_REQUEST);
+            }
         } else {
             return new ResponseEntity<>("팀장만 생성 가능합니다.", HttpStatus.FORBIDDEN);
         }

--- a/src/main/java/com/slamdunk/WORK/service/UserObjectiveService.java
+++ b/src/main/java/com/slamdunk/WORK/service/UserObjectiveService.java
@@ -39,11 +39,8 @@ public class UserObjectiveService {
         List<UserObjective> userObjectiveList = userObjectiveRepository.findAllByTeam(userDetails.getUser().getTeam());
 
         List<Long> objectiveIdList = new ArrayList<>();
-        for (int i=0; i<userObjectiveList.size(); i++) {
-            Optional<Objective> objective = objectiveRepository.findByIdAndDeleteStateFalse(userObjectiveList.get(i).getObjective().getId());
-            if (objective.isPresent()) {
-                objectiveIdList.add(userObjectiveList.get(i).getObjective().getId());
-            }
+        for (int i = 0; i < userObjectiveList.size(); i++) {
+            objectiveIdList.add(userObjectiveList.get(i).getObjective().getId());
         }
 
         return objectiveIdList;


### PR DESCRIPTION
- 목표 생성 갯수를 4개로 제한
- 목표 관련 조회 api의 정렬 순서를 종료일이 가장 빠른 순서로 응답